### PR TITLE
Exceptions for Amazon AWS

### DIFF
--- a/src/ext_data/known_cookies.json
+++ b/src/ext_data/known_cookies.json
@@ -11,6 +11,9 @@
             "newUser": 0,
             "userId": 0
         },
+        "amazon.com": {
+            "aws-userInfo": 0
+        },
         "azure.com": {
             "LPVID": 0
         },

--- a/src/ext_data/known_cookies.json
+++ b/src/ext_data/known_cookies.json
@@ -14,6 +14,9 @@
         "amazon.com": {
             "aws-userInfo": 0
         },
+        "aws.amazon.com": {
+            "aws-account-data": 0
+        },
         "azure.com": {
             "LPVID": 0
         },


### PR DESCRIPTION
Cookies that are incorrectly classified and break usage of Amazon Web Services Console